### PR TITLE
Add the Ability to Keep Individual Files and Filter the Files List

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,32 @@ Vuepress plugin for exporting site as PDF
 - Designed to work well in headless environments like CI runners
 
 ## Config options
+- `filter` - function for filtering pages (default `false`)
+- `individualPdfFolder` - string (default temp dir), if supplied will save the individual PDFs and a `files.json` file
+    with the title, url, location, path, key, and frontmatter for each PDF to allow later combining/mapping
 - `theme` - theme name (default `@vuepress/default`)
-- `sorter` - function for changing pages order (default `false`)
-- `outputFileName` - name of output file (default `site.pdf`)
+- `outputFileName` - name of output file (default `site.pdf`, or null to skip creating a combined file (useful if saving individual PDFs))
 - `puppeteerLaunchOptions` - [Puppeteer launch options object](https://github.com/puppeteer/puppeteer/blob/v2.1.1/docs/api.md#puppeteerlaunchoptions) (default `{}`)
 - `pageOptions` - [Puppeteer page formatting options object](https://github.com/puppeteer/puppeteer/blob/v2.1.1/docs/api.md#pagepdfoptions) (default `{format: 'A4'}`)
+- `sorter` - function for changing pages order (default `false`)
 
-### Usage
+### Sort/Filter Functions
+
+The input to each is page object(s) from Vuepress context:
+[https://vuepress.vuejs.org/plugin/context-api.html#ctx-pages](https://vuepress.vuejs.org/plugin/context-api.html#ctx-pages)
+
+There is better documenation about the properties of a page object currently available at:
+[https://vuepress.vuejs.org/plugin/option-api.html#extendpagedata](https://vuepress.vuejs.org/plugin/option-api.html#extendpagedata)
+
+At the time of writing all the keys available were:
+`title`, `_meta`, `_filePath`, `_content`, `_permalink`, `frontmatter`, `_permalinkPattern`, `_extractHeaders`,
+`_context`, `regularPath`, `relativePath`, `key`, `path`, `_strippedContent`, `headers`, `_computed`, `_localePath`
+
+Sort will receive `(a, b)` where `a` and `b` are page objects and should return an integer.
+
+Filter will receive a page object and the index and should return `true`/`false`.
+
+## Usage
 
 Using this plugin:
 
@@ -23,6 +42,42 @@ Using this plugin:
 module.exports = {
   plugins: ['@snowdog/vuepress-plugin-pdf-export']
 }
+```
+
+Using the plugin with options:
+
+```js
+// in .vuepress/config.js
+module.exports = {
+    // ...
+    plugins: [
+        // ...
+        [
+            require("../../vuepress-plugin-pdf-export"),
+            {
+                // options to override
+                outputFileName: null,
+                pageOptions: {
+                    format: 'Letter',
+                    printBackground: true,
+                    displayHeaderFooter: false,
+                    headerTemplate: "",
+                    footerTemplate: "",
+                    margin: {
+                        top: "1in",
+                        left: "1in",
+                        right: "1in",
+                        bottom: "1in",
+                    }
+                },
+                individualPdfFolder: 'build/pdf',
+                filter: (a) =>  !a?.frontmatter?.home,
+                sorter: (a, b) =>  a.path < b.path ? -1 : 1,
+            }
+        ]
+    ],
+    // ...
+};
 ```
 
 Then run:

--- a/src/extendCli.js
+++ b/src/extendCli.js
@@ -7,10 +7,12 @@ const generatePDF = require('./generatePdf')
 
 module.exports = options => {
   const theme = options.theme || '@vuepress/default'
+  const filter = options.filter || false
   const sorter = options.sorter || false
-  const outputFileName = options.outputFileName || 'site.pdf'
+  const outputFileName = options.outputFileName === null ? null : options.outputFileName || 'site.pdf'
   const puppeteerLaunchOptions = options.puppeteerLaunchOptions || {}
   const pageOptions = options.pageOptions || {}
+  const individualPdfFolder = options.individualPdfFolder;
 
   return cli => {
     cli
@@ -30,12 +32,14 @@ module.exports = options => {
 
         try {
           await generatePDF(nCtx, {
-            port: nCtx.devProcess.port,
+            filter,
             host: nCtx.devProcess.host,
-            sorter,
+            individualPdfFolder,
             outputFileName,
+            pageOptions,
+            port: nCtx.devProcess.port,
             puppeteerLaunchOptions,
-            pageOptions
+            sorter,
           })
         } catch (error) {
           console.error(red(error))


### PR DESCRIPTION
- Adds the ability to keep the individual PDF files around and export details (useful for later combining).
    - I have a custom utility to bind in a table of contents, outline.  Sadly, it's Swift/a mac binary so not generally useful as part of this project, but it is public https://github.com/loren138/mac-pdfnup
- Adds the a `filter` function to allow filtering out certain files

If you ignore whitespace changes in the diff, it will be smaller. (I added an if statement for exporting the combined PDF which changed several lines.)

Also, I added a good number of lines to the readme.