### PR TITLE
Add an optional features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-# @snowdog/vuepress-plugin-pdf-export
+# @e8johan/vuepress-plugin-pdf-export
+
 Vuepress plugin for exporting site as PDF
+
+This is a fork of @snowdog/vuepress-plugin-pdf-export. All changes are available in a PR to the upstream repository. Use this package at your own peril.
 
 ## Features
 - Exports whole Vuepress based page as a single PDF file

--- a/README.md
+++ b/README.md
@@ -9,11 +9,14 @@ This is a fork of @snowdog/vuepress-plugin-pdf-export. All changes are available
 - Applies styles to hide UI elements like navigation or sidebar
 - Doesn't require other runtimes like Java to operate
 - Designed to work well in headless environments like CI runners
+- Can filter and sort pages.
+- Can generate a rudimentary table of contents
 
 ## Config options
 - `theme` - theme name (default `@vuepress/default`)
 - `sorter` - function for changing pages order (default `false`)
 - `filter` - function for filtering the pages (default `false`)
+- `tocLevel` - function returning a TOC level for the pages, i.e. zero or one (default `false`)
 - `outputFileName` - name of output file (default `site.pdf`)
 - `puppeteerLaunchOptions` - [Puppeteer launch options object](https://github.com/puppeteer/puppeteer/blob/v2.1.1/docs/api.md#puppeteerlaunchoptions) (default `{}`)
 - `pageOptions` - [Puppeteer page formatting options object](https://github.com/puppeteer/puppeteer/blob/v2.1.1/docs/api.md#pagepdfoptions) (default `{format: 'A4'}`)
@@ -35,6 +38,30 @@ Then run:
 vuepress export [path/to/your/docs]
 ```
 
+#### The filter function
+
+The `filter` function takes a `pages` object and returns `true` or `false`. Only pages where the function returns `true` are rendered to the pdf. The function is invoked as follows:
+
+```
+exportPages = exportPages.filter(filter);
+```
+
+#### The sorter function
+
+The `sorter` function takes two `pages` objects and return `-1`, `0`, or `1` to indicate the sort order. The function is invoked as follows:
+
+```
+exportPages = exportPages.sort(sorter)
+```
+
+The sorting happens after the filtering, so you only have to handle the pages that pass your filter function.
+
+#### The tocLevel function
+
+The `tocLevel` function takes a `pages` object returns a TOC level, either zero (`0`, top level) or one (`1`, secondary level), or minus one (`-1`, leave out of TOC). If the entire TOC is empty, e.g. every page is on level `-1`, no TOC is rendered.
+
+The TOC generation is invoked after the filtering and sorting. So the list of pages can be assumed to be filtered.
+
 ### Tips
 To run this plugin on Gitlab CI you may want to run Chrome with `no-sandbox` flag. [Details](https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#setting-up-chrome-linux-sandbox)
 
@@ -49,3 +76,7 @@ module.exports = {
   ]
 }
 ```
+
+## Known Issues
+
+- At the moment, pdfjs cannot inject footers on the rendered pages, and the individual pages do not know their page number, so the page numbers in the TOC relates to the page numbers in the PDF, but no page number is rendered on the actual PDF pages.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Vuepress plugin for exporting site as PDF
 ## Config options
 - `theme` - theme name (default `@vuepress/default`)
 - `sorter` - function for changing pages order (default `false`)
+- `filter` - function for filtering the pages (default `false`)
 - `outputFileName` - name of output file (default `site.pdf`)
 - `puppeteerLaunchOptions` - [Puppeteer launch options object](https://github.com/puppeteer/puppeteer/blob/v2.1.1/docs/api.md#puppeteerlaunchoptions) (default `{}`)
 - `pageOptions` - [Puppeteer page formatting options object](https://github.com/puppeteer/puppeteer/blob/v2.1.1/docs/api.md#pagepdfoptions) (default `{format: 'A4'}`)

--- a/README.md
+++ b/README.md
@@ -11,12 +11,14 @@ This is a fork of @snowdog/vuepress-plugin-pdf-export. All changes are available
 - Designed to work well in headless environments like CI runners
 - Can filter and sort pages.
 - Can generate a rudimentary table of contents
+- Can insert a front page (or front pages)
 
 ## Config options
 - `theme` - theme name (default `@vuepress/default`)
 - `sorter` - function for changing pages order (default `false`)
 - `filter` - function for filtering the pages (default `false`)
 - `tocLevel` - function returning a TOC level for the pages, i.e. zero or one (default `false`)
+- `frontPage` - path to a pdf to inject first in the document. Typically a front page, but can be multiple pages too.
 - `outputFileName` - name of output file (default `site.pdf`)
 - `puppeteerLaunchOptions` - [Puppeteer launch options object](https://github.com/puppeteer/puppeteer/blob/v2.1.1/docs/api.md#puppeteerlaunchoptions) (default `{}`)
 - `pageOptions` - [Puppeteer page formatting options object](https://github.com/puppeteer/puppeteer/blob/v2.1.1/docs/api.md#pagepdfoptions) (default `{format: 'A4'}`)

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@snowdog/vuepress-plugin-pdf-export",
-  "version": "1.1.0",
+  "name": "@e8johan/vuepress-plugin-pdf-export",
+  "version": "1.2.0",
   "license": "MIT",
-  "repository": "SnowdogApps/vuepress-plugin-pdf-export",
+  "repository": "e8johan/vuepress-plugin-pdf-export",
   "scripts": {
     "lint": "eslint src/*.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e8johan/vuepress-plugin-pdf-export",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "license": "MIT",
   "repository": "e8johan/vuepress-plugin-pdf-export",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e8johan/vuepress-plugin-pdf-export",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "license": "MIT",
   "repository": "e8johan/vuepress-plugin-pdf-export",
   "scripts": {

--- a/src/extendCli.js
+++ b/src/extendCli.js
@@ -10,6 +10,7 @@ module.exports = options => {
   const sorter = options.sorter || false
   const filter = options.filter || false
   const tocLevel = options.tocLevel || false
+  const frontPage = options.frontPage || false
   const outputFileName = options.outputFileName || 'site.pdf'
   const puppeteerLaunchOptions = options.puppeteerLaunchOptions || {}
   const pageOptions = options.pageOptions || {}
@@ -37,6 +38,7 @@ module.exports = options => {
             sorter,
             filter,
             tocLevel,
+            frontPage,
             outputFileName,
             puppeteerLaunchOptions,
             pageOptions

--- a/src/extendCli.js
+++ b/src/extendCli.js
@@ -9,6 +9,7 @@ module.exports = options => {
   const theme = options.theme || '@vuepress/default'
   const sorter = options.sorter || false
   const filter = options.filter || false
+  const tocLevel = options.tocLevel || false
   const outputFileName = options.outputFileName || 'site.pdf'
   const puppeteerLaunchOptions = options.puppeteerLaunchOptions || {}
   const pageOptions = options.pageOptions || {}
@@ -35,6 +36,7 @@ module.exports = options => {
             host: nCtx.devProcess.host,
             sorter,
             filter,
+            tocLevel,
             outputFileName,
             puppeteerLaunchOptions,
             pageOptions

--- a/src/extendCli.js
+++ b/src/extendCli.js
@@ -8,6 +8,7 @@ const generatePDF = require('./generatePdf')
 module.exports = options => {
   const theme = options.theme || '@vuepress/default'
   const sorter = options.sorter || false
+  const filter = options.filter || false
   const outputFileName = options.outputFileName || 'site.pdf'
   const puppeteerLaunchOptions = options.puppeteerLaunchOptions || {}
   const pageOptions = options.pageOptions || {}
@@ -33,6 +34,7 @@ module.exports = options => {
             port: nCtx.devProcess.port,
             host: nCtx.devProcess.host,
             sorter,
+            filter,
             outputFileName,
             puppeteerLaunchOptions,
             pageOptions

--- a/src/generatePdf.js
+++ b/src/generatePdf.js
@@ -39,6 +39,7 @@ module.exports = async (ctx, {
   sorter,
   filter,
   tocLevel,
+  frontPage,
   outputFileName,
   puppeteerLaunchOptions,
   pageOptions
@@ -142,6 +143,13 @@ module.exports = async (ctx, {
         paddingTop: 25.4 * pdf.mm,
         paddingBottom: 37.6 * pdf.mm,
       });
+
+      if (frontPage !== false) {
+        const file = fs.readFileSync(frontPage)
+        const page = new pdf.ExternalDocument(file)
+        mergedPdf.addPagesOf(page);
+        tocPageCount += page.pageCount;
+      }
 
       if (toc.length > 0) {
         _createToc(mergedPdf, toc, tocPageCount);

--- a/src/generatePdf.js
+++ b/src/generatePdf.js
@@ -8,6 +8,7 @@ module.exports = async (ctx, {
   port,
   host,
   sorter,
+  filter,
   outputFileName,
   puppeteerLaunchOptions,
   pageOptions
@@ -17,6 +18,10 @@ module.exports = async (ctx, {
   fs.ensureDirSync(tempDir)
 
   let exportPages = pages.slice(0)
+
+  if (typeof filter === 'function') {
+    exportPages = exportPages.filter(filter);
+  }
 
   if (typeof sorter === 'function') {
     exportPages = exportPages.sort(sorter)

--- a/src/generatePdf.js
+++ b/src/generatePdf.js
@@ -4,11 +4,41 @@ const { join } = require('path')
 const { fs, logger, chalk } = require('@vuepress/shared-utils')
 const { yellow, gray } = chalk
 
+function _createToc(doc, toc, tocPageCount) {
+  doc.text('Table of Contents', { fontSize: 20 });
+  doc.text(' ', { fontSize: 8 });
+  const table = doc.table({
+    widths: [5 * pdf.mm, (210-85.8) * pdf.mm, 30 * pdf.mm],
+    padding: 0,
+    borderWidth: 0
+  });
+  let currentPage = tocPageCount;
+  if (currentPage == -1)
+    currentPage = 9998;
+
+  toc.forEach(t => {
+    const row = table.row();
+    if (t.tocLevel == 0) {
+      row.cell(t.title, {fontSize: 11, textAlign: 'left', colspan: 2});
+      row.cell((currentPage+1).toString(), {fontSize: 11, textAlign: 'right'});
+    } else if (t.tocLevel == 1) {
+      row.cell('', {fontSize: 11, textAlign: 'left'});
+      row.cell(t.title, {fontSize: 11, textAlign: 'left'});
+      row.cell((currentPage+1).toString(), {fontSize: 11, textAlign: 'right'});
+    }
+    // Other toc levels mean skipping the entry
+
+    if (tocPageCount != -1)
+      currentPage += t.pageCount;
+  });
+}
+
 module.exports = async (ctx, {
   port,
   host,
   sorter,
   filter,
+  tocLevel,
   outputFileName,
   puppeteerLaunchOptions,
   pageOptions
@@ -16,6 +46,11 @@ module.exports = async (ctx, {
   const { pages, tempPath } = ctx
   const tempDir = join(tempPath, 'pdf')
   fs.ensureDirSync(tempDir)
+
+  // Default toc level if not specified
+  if (typeof tocLevel !== 'function') {
+    tocLevel = function() { return -1; }
+  }
 
   let exportPages = pages.slice(0)
 
@@ -32,7 +67,8 @@ module.exports = async (ctx, {
       url: page.path,
       title: page.title,
       location: `http://${host}:${port}${page.path}`,
-      path: `${tempDir}/${page.key}.pdf`
+      path: `${tempDir}/${page.key}.pdf`,
+      relativePath: page.relativePath
     }
   })
 
@@ -64,24 +100,74 @@ module.exports = async (ctx, {
   }
 
   await new Promise(resolve => {
-    const mergedPdf = new pdf.Document()
-
-    exportPages
-      .map(({ path }) => fs.readFileSync(path))
-      .forEach(file => {
+    // Build the TOC (collect page numbers, etc)
+    var toc = []
+    for (let i = 0; i < exportPages.length; i++) {
+        const {
+          relativePath,
+          path,
+          title
+        } = exportPages[i]
+        const file = fs.readFileSync(path)
         const page = new pdf.ExternalDocument(file)
-        mergedPdf.addPagesOf(page)
-      })
+        const tl = tocLevel(exportPages[i])
+        if (tl == 0 || tl == 1) {
+          toc.push({tocLevel: tl, title: title, pageCount: page.pageCount})
+        }
+    }
 
-    mergedPdf.asBuffer((err, data) => {
+    // Generate and TOC without page numbers to count pages
+    const tocPdf = new pdf.Document({
+      paddingLeft: 25.4 * pdf.mm,
+      paddingRight: 25.4 * pdf.mm,
+      paddingTop: 25.4 * pdf.mm,
+      paddingBottom: 37.6 * pdf.mm,
+    });
+    if (toc.length > 0) {
+      _createToc(tocPdf, toc, -1);
+    }
+    let tocPageCount = -1;
+    tocPdf.asBuffer((err, data) => {
       if (err) {
-        throw err
+        throw err;
       } else {
-        fs.writeFileSync(outputFileName, data, { encoding: 'binary' })
-        logger.success(`Export ${yellow(outputFileName)} file!`)
-        resolve()
+        const tocPages = new pdf.ExternalDocument(data);
+        tocPageCount = tocPages.pageCount;
       }
-    })
+    }).finally(x => {
+      // Merge the pages, but first, insert the TOC
+      const mergedPdf = new pdf.Document({
+        paddingLeft: 25.4 * pdf.mm,
+        paddingRight: 25.4 * pdf.mm,
+        paddingTop: 25.4 * pdf.mm,
+        paddingBottom: 37.6 * pdf.mm,
+      });
+
+      if (toc.length > 0) {
+        _createToc(mergedPdf, toc, tocPageCount);
+      } else {
+        tocPageCount = 0;
+      }
+
+      for (let i = 0; i < exportPages.length; i++) {
+          const {
+            path,
+          } = exportPages[i]
+          const file = fs.readFileSync(path)
+          const page = new pdf.ExternalDocument(file)
+          mergedPdf.addPagesOf(page)
+      }
+
+      mergedPdf.asBuffer((err, data) => {
+        if (err) {
+          throw err
+        } else {
+          fs.writeFileSync(outputFileName, data, { encoding: 'binary' })
+          logger.success(`Export ${yellow(outputFileName)} file!`)
+          resolve()
+        }
+      })
+    });
   })
 
   await browser.close()


### PR DESCRIPTION
Add a new filter function to the options that let's you filter the pages, to be able to remove pages that only apply to the web site and not the PDF export.

Added a TOC function, rendering an optional TOC before the rendered pages.

Added the ability to inject a front page (or front pages) before the TOC.

(sorry for mixing multiple features, my fork is moving forward due to project needs)